### PR TITLE
Kaboom

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Features
 --------
 
 - Cross platform
+- Kaboom mode:
+  - Cruel but fair mode, where guessing is punished, 
+  but when only guesses are left you are guaranteed not to be wrong.
+  - Based on the blog post [here](https://pwmarcz.pl/blog/kaboom/).
 - Keyboard or mouse (or hybrid) control
 - Standard and Knight's move modes
 - QoL features:

--- a/README.md
+++ b/README.md
@@ -3,18 +3,19 @@ Minesweeper
 
 Simple terminal based minesweeper. Python 3 required.
 
-![minesweeper](https://gazpachoking.github.io/minesweeper/minesweeper.png)
+![minesweeper](https://gazpachoking.github.io/minesweeper/double.width.characters.png)
 
 Features
 --------
 
 - Cross platform
 - Kaboom mode:
-  - Cruel but fair mode, where guessing is punished, 
+  - Cruel but fair, where guessing is punished, 
   but when only guesses are left you are guaranteed not to be wrong.
   - Based on the blog post [here](https://pwmarcz.pl/blog/kaboom/).
 - Keyboard or mouse (or hybrid) control
 - Standard and Knight's move modes
+- Double-width characters (if your terminal supports it)
 - QoL features:
   - Highlight adjacent tiles
   - Clear all adjacent

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ CLI
 
 - **--size X Y** Specify field size
 - **--mines N** Specify number (or fraction of board) of mines
-
+- **--niceness cruel|normal|fair|nice**
+  - **nice** Any click that could result in an empty tile is an empty tile.
+  - **fair** If guessing is the only move available, you will not guess wrong.
+  - **normal** Traditional minesweeper.
+  - **cruel** Any click that could result in a mine is a mine. (Except when guessing is the only move available.)
+- **--style single|double** double mode uses full width unicode characters to
+  double the cell size. Use single if this causes problems with your terminal. 
 
   
 

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -182,6 +182,7 @@ class Board:
         if not tile.num_adjacent_mines:
             self.reveal_all(tile.pos)
         if self.is_loss():
+            self.status = GameState.LOST
             self.end_time = time.time()
         elif self.is_win():
             self.status = GameState.WON

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -286,11 +286,12 @@ class MineField(Widget):
                     color = Screen.COLOUR_RED
                     char = "X" * CHAR_WIDTH
             else:
-                if not tile.revealed and tile.determined:
-                    if tile.mine:
-                        color = Screen.COLOUR_RED
-                    else:
-                        color = Screen.COLOUR_GREEN
+                # Debug (cheater) coloring
+                # if not tile.revealed and tile.determined:
+                #     if tile.mine:
+                #         color = Screen.COLOUR_RED
+                #     else:
+                #         color = Screen.COLOUR_GREEN
                 if tile is cursor:
                     bg = Screen.COLOUR_YELLOW
                 if cursor.revealed:

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -155,7 +155,7 @@ class Board:
         """Determine any tiles that should no longer be variable."""
         solver = self.solver()
         # Lock in certain tiles that must/must not be mines.
-        for t in self.tiles(revealed=False):
+        for t in self.tiles(revealed=False, determined=False, boundary=True):
             can_be_mine = solver.check(t.var) == z3.sat
             can_be_open = solver.check(z3.Not(t.var)) == z3.sat
             if not (can_be_mine and can_be_open):

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -192,13 +192,14 @@ class Board:
         if changed:
             self.replace_mines()
 
+        tile.revealed = True
+
         if tile.mine:
             self.status = GameState.LOST
             self.end_time = time.time()
             return
 
         tile.num_adjacent_mines = sum(1 for n in tile.neighbors if n.mine)
-        tile.revealed = True
         if not tile.num_adjacent_mines:
             self.reveal_all(tile.pos, cascade=True)
         # Once all new tiles have been revealed, lock in any tiles which can no longer be changed
@@ -269,11 +270,12 @@ class MineField(Widget):
                 color = Screen.COLOUR_RED
                 char = "＃"
             elif not tile.revealed:
-                char = "░" * CHAR_WIDTH
+                bg = Screen.COLOUR_WHITE
+                char = "\u3000"  # Full width space
             elif tile.num_adjacent_mines:
-                char = str(chr(ord(str(tile.num_adjacent_mines)) + 0xFEE0))
+                char = chr(ord(str(tile.num_adjacent_mines)) + 0xFEE0)
             else:
-                char = " " * CHAR_WIDTH
+                char = "\u3000"
             if self._board.status in [GameState.WON, GameState.LOST]:
                 if tile.marked and tile.mine:
                     color = Screen.COLOUR_GREEN
@@ -281,10 +283,12 @@ class MineField(Widget):
                     color = Screen.COLOUR_GREEN
                     if tile.revealed:
                         color = Screen.COLOUR_RED
-                    char = "*" * CHAR_WIDTH
+                    char = "＊"
                 elif tile.marked:
                     color = Screen.COLOUR_RED
-                    char = "X" * CHAR_WIDTH
+                    char = "Ｘ"
+                if tile.determined and not tile.mine and not tile.revealed:
+                    bg = Screen.COLOUR_YELLOW
             else:
                 # Debug (cheater) coloring
                 # if not tile.revealed and tile.determined:

--- a/minesweeper.py
+++ b/minesweeper.py
@@ -302,7 +302,7 @@ class MineField(Widget):
                     if tile in adjacent and not tile.revealed:
                         bg = Screen.COLOUR_CYAN
             self._frame.canvas.paint(
-                char, self._x + (tile.pos.x * CHAR_WIDTH), self._y + tile.pos.y, color, bg=bg
+                char, self._x + (tile.pos.x * CHAR_WIDTH), self._y + tile.pos.y, color, bg=bg, attr=Screen.A_BOLD,
             )
 
     def reset(self):

--- a/poetry.lock
+++ b/poetry.lock
@@ -74,8 +74,16 @@ optional = false
 python-versions = "*"
 version = "0.1.8"
 
+[[package]]
+category = "main"
+description = "an efficient SMT solver library"
+name = "z3-solver"
+optional = true
+python-versions = "*"
+version = "4.8.7.0"
+
 [metadata]
-content-hash = "21afc93343dea4d21fb4432dc0101af9c8f7f1e8f33258a7548f2b322b19a6ea"
+content-hash = "b41c3fd7c19238f0145534369574b3d8bd00bfd1e68fc77b334b0bc6e9fcde50"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -139,4 +147,10 @@ pywin32 = [
 wcwidth = [
     {file = "wcwidth-0.1.8-py2.py3-none-any.whl", hash = "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603"},
     {file = "wcwidth-0.1.8.tar.gz", hash = "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"},
+]
+z3-solver = [
+    {file = "z3-solver-4.8.7.0.tar.gz", hash = "sha256:a9bf7b9fab66ca652675bf8d4b67d1a9301a017d1eebe118d05bf7200541b62c"},
+    {file = "z3_solver-4.8.7.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:ecdf7cb3df9661bdc8953a552a7c09e1c0b7f4195e5eeeab8ff90f672490bf3f"},
+    {file = "z3_solver-4.8.7.0-py2.py3-none-win32.whl", hash = "sha256:922158453b235ad6c3d45d9c8ed2b427c65d077d65ddcef3cc65f6a4ac7696ac"},
+    {file = "z3_solver-4.8.7.0-py2.py3-none-win_amd64.whl", hash = "sha256:7e04e1b56a100f4fef79c2f20be0aeb6dac4efc6ab66ba5bac41dbe6820cbd7e"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -78,12 +78,12 @@ version = "0.1.8"
 category = "main"
 description = "an efficient SMT solver library"
 name = "z3-solver"
-optional = true
+optional = false
 python-versions = "*"
 version = "4.8.7.0"
 
 [metadata]
-content-hash = "b41c3fd7c19238f0145534369574b3d8bd00bfd1e68fc77b334b0bc6e9fcde50"
+content-hash = "4c8c95255c14cc16b6bc970de4ce9df5db371b6f556426ac76727cb2b552d029"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ license = "MIT"
 python = "^3.6"
 asciimatics = "^1.11.0"
 click = "^7.0"
+z3-solver = {version = "^4.8.7", optional = true}
+
+[tool.poetry.extras]
+noguess = ["z3-solver"]
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,7 @@ license = "MIT"
 python = "^3.6"
 asciimatics = "^1.11.0"
 click = "^7.0"
-z3-solver = {version = "^4.8.7", optional = true}
-
-[tool.poetry.extras]
-noguess = ["z3-solver"]
+z3-solver = "^4.8.7"
 
 [tool.poetry.dev-dependencies]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyfiglet==0.8.post1
 pypiwin32==223; sys_platform == "win32"
 pywin32==227; sys_platform == "win32"
 wcwidth==0.1.8
+z3-solver==4.8.7.0


### PR DESCRIPTION
Multiple improvements in this branch:
- New styling, including double-wide squares (using fullwidth unicode characters)
- Kaboom mode, as seen [here](https://pwmarcz.pl/blog/kaboom/) by Paweł Marczewski. Will allow many options to do with discouraging guessing when not required, and ensuring you never lose because of forced guessing.

TODO:
- [x] Make options for a bunch of stuff.
  - [x] Cruel/nice/normal mode. What happens when you guess. cruel=you are always wrong. nice=you are always right. normal=random, like the normal version. (all within constraints of the revealed tiles of course)
  - [x] Turn fair mode on/off. (it'd be required in cruel mode though)
  - [x] Double/single width tiles. The fullwidth unicode is a bit finicky in many terminals
- ~Make an options file supported so default options can be saved.~ delaying
- ~Make an in-game options editor~ Delaying this
- ~Make normal mode without all the guessing backend logic possible again. (it can maybe be a bit slow, although it's not really noticeable on my machine)~ delaying